### PR TITLE
attempt to add playwright step

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -213,8 +213,12 @@ jobs:
       - name: Run veda setup
         run: ./.veda/setup
 
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+      - name: Checkout generate_env script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            /scripts/generate_env_file.py
+          sparse-checkout-cone-mode: false
 
       - name: Generate .env file from cdk.out
         shell: bash
@@ -222,7 +226,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           python "${{ github.workspace }}/scripts/generate_env_file.py" --secret-id ${{ vars.DEPLOYMENT_ENV_SECRET_NAME }} --stack-names "${{ needs.deploy-veda-backend.outputs.backend_stack_name }}"
-
 
       - name: Load .env file
         id: dotenv
@@ -240,6 +243,9 @@ jobs:
           cat .env.local
 
           echo "MAPBOX_TOKEN="$MAPBOX_TOKEN" >> .env.local
+
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
 
       - name: Playwright tests
         run: yarn test:e2e


### PR DESCRIPTION
attempting to add running playwright step.

For veda-config to run on localhost, there are 3 steps, 
1. must run ./.veda/setup
2. Must create a .env.local
3. That env.local file must have MAPBOX_TOKEN

We  also need to add the API_RASTER_ENDPOINT and API_STAC_ENDPOINT to that local env file with our URLs for the deployment under test (to overwrite the stage URLs for those values in the .env in the veda-config repo)

notes: 

1. current setup points to specific branch in veda-config while that PR is in flight
