### PR TITLE
fix: invalid url paths in health check

### DIFF
--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -6,16 +6,37 @@ load_dotenv()
 
 
 def test_stac_url_returns_200():
-    endpoint = os.getenv("VEDA_STAC_URL")
-    stac_path_prefix = os.getenv("VEDA_STAC_PATH_PREFIX")
-    url = f"{endpoint.rstrip('/')}/{stac_path_prefix}/_mgmt/ping"
+    base_url = os.getenv("VEDA_STAC_URL")
+    stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
+    custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
+    health_endpoint = "_mgmt/ping"
+    
+    url = f"{base_url}{health_endpoint}"
+    print(f"Checking APIGW stac-api {url=}")
     response = requests.get(url)
     assert response.status_code == 200
+
+    if custom_host:
+        url = f"https://{custom_host}/{stac_root_path.rstrip('/')}/{health_endpoint}"
+        print(f"Checking custom host stac-api {url=}")
+        response = requests.get(url)
+        assert response.status_code == 200
+    
 
 
 def test_raster_url_returns_200():
-    endpoint = os.getenv("VEDA_RASTER_URL")
-    raster_path_prefix = os.getenv("VEDA_RASTER_PATH_PREFIX")
-    url = f"{endpoint.rstrip('/')}/{raster_path_prefix}/healthz"
+    base_url = os.getenv("VEDA_RASTER_URL")
+    raster_root_path = os.getenv("VEDA_RASTER_ROOT_PATH")
+    custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
+    health_endpoint = "healthz"
+
+    url = os.path.join(base_url, health_endpoint)
+    print(f"Checking APIGW raster-api {url=}")
     response = requests.get(url)
     assert response.status_code == 200
+
+    if custom_host:
+        url = f"https://{custom_host}/{raster_root_path.rstrip('/')}/{health_endpoint}"
+        print(f"Checking custom host raster-api {url=}")
+        response = requests.get(url)
+        assert response.status_code == 200


### PR DESCRIPTION
- Updated stac and raster api urls in integration tests to match current variable names from cdk out
- Added testing for urls behind proxy if custom host is in cdk out