### PR TITLE
shorten the role session name for aws action char limit, still making it comprehensible.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "${{ env.DIRECTORY }}-github-${{ env.ENVIRONMENT }}-auth-deployment"
+          role-session-name: "gh-${{ env.ENVIRONMENT }}-auth-deployment"
           aws-region: "us-west-2"
 
       - name: Run auth deployment
@@ -89,7 +89,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "${{ env.DIRECTORY }}-github-${{ env.ENVIRONMENT }}-backend-deployment"
+          role-session-name: "gh-${{ env.ENVIRONMENT }}-backend-deployment"
           aws-region: "us-west-2"
 
       - name: Run deployment
@@ -177,7 +177,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "${{ env.DIRECTORY }}-github-${{ env.ENVIRONMENT }}-integration-test"
+          role-session-name: "gh-${{ env.ENVIRONMENT }}-integration-test"
           aws-region: "${{ env.AWS_DEFAULT_REGION }}"
 
       - name: Install python dependencies


### PR DESCRIPTION
# Context
Error in [this action run](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/9324113964/job/25670621299)
```
Error: Could not assume role with OIDC: 1 validation error detected: Value 'veda-data-airflow-github-ghgc-mcp-production-blue-airflow-deployment' at 'roleSessionName' failed to satisfy constraint: Member must have length less than or equal to 64
```

Shorten the role session name to fix aws action char limit (still making it comprehensible), which occurs when the char length exceeds 64 chars.