### PR TITLE
feat: update cicd.yml to support checkout of tags for veda-data-airflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -133,8 +133,8 @@ jobs:
           cd ${{ env.DIRECTORY }}
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
           git fetch --tags origin
-          echo `git checkout origin/${{ vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main' }}`
-          git checkout origin/${{ vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main'}}
+          echo `git checkout ${{ vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main' }}`
+          git checkout ${{ vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main'}}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -142,7 +142,7 @@ jobs:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "${{ env.DIRECTORY }}-github-${{ env.ENVIRONMENT }}-airflow-deployment"
           aws-region: "${{ env.AWS_REGION }}"
-          
+
       - name: Run deployment
         uses: "./veda-data-airflow/.github/actions/terraform-deploy"
         with:


### PR DESCRIPTION
### Changes
- Update cicd.yml file to remove `origin/` in the `git checkout` in order to support setting `VEDA_DATA_AIRFLOW_GIT_REF` to a tag as opposed to a branch

### Notes
Our other checkouts do not include `origin/`
- https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/cicd.yml#L38
- https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/cicd.yml#L85-L86
