### PR TITLE
fix: change submodule checkout

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           repository: "NASA-IMPACT/${{ env.DIRECTORY }}"
           path: ${{ env.DIRECTORY }}
-          ref: ${{ vars.vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main'}}
+          ref: ${{ vars.VEDA_DATA_AIRFLOW_GIT_REF || 'main'}}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -159,7 +159,7 @@ jobs:
       AWS_REGION: "us-west-2"
       ENVIRONMENT: ${{ github.event.inputs.environment }}
       GH_PAT_CHECK: ${{ secrets.GH_PAT }}
-    needs: [deploy-veda-auth, deploy-veda-backend]
+    needs: [deploy-veda-auth, deploy-veda-backend, deploy-veda-data-airflow]
     environment: ${{ github.event.inputs.environment }}
 
     steps:


### PR DESCRIPTION
Since the veda-monitoring repo is private, doing a "recursive" submodule checkout without providing a PAT will result in an error pulling the veda-monitoring repo. Since we don't need all the submodules for each deployment phase, we can only checkout one submodule at a time. Then we only need to provide the PAT when accessing veda-monitoring.