### PR TITLE
fix: add job outputs for veda-backend

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -148,6 +148,10 @@ jobs:
 
     outputs:
       backend_stack_name: ${{ steps.get_backend_stack.outputs.backend_stackname }}
+      raster_api_url: ${{ steps.get_backend_stack.outputs.raster_api_url }}
+      ingest_api_url: ${{ steps.get_backend_stack.outputs.ingest_api_url }}
+      stac_api_url: ${{ steps.get_backend_stack.outputs.stac_api_url }}
+      stack_browser_bucket_name: ${{ steps.get_backend_stack.outputs.stack_browser_bucket_name }}
 
   deploy-veda-data-airflow:
     name: deploy VEDA data airflow 🍃


### PR DESCRIPTION
# What this PR is

Just noticed I'd not specified job outputs for `deploy-veda-backend`, so adding those in
