### PR TITLE
Adding github actions inputs to control the deployments of VEDA components

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ on:
       DEPLOY_DATA_AIRFLOW:
         type: boolean
         required: true
-        default: true
+        default: false
         description: DEPLOY_DATA_AIRFLOW
       DEPLOY_FEATURES_API:
         type: boolean
@@ -39,7 +39,7 @@ on:
       DEPLOY_SM2A:
         type: boolean
         required: true
-        default: true
+        default: false
         description: DEPLOY_SM2A
       DEPLOY_MONITORING:
         type: boolean


### PR DESCRIPTION
Control the deployment of VEDA components from github workflow inputs instead of github vars. 