### PR TITLE
fix: expand deploy run name to describe environment and components

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,7 +12,6 @@ on:
         type: environment
         required: true
         description: Environment to deploy to
-        default: none
       DEPLOY_AUTH:
         type: boolean
         required: true


### PR DESCRIPTION
Expand deploy run name to describe environment and components so individual dispatches can be identified in action log