### PR TITLE
Improve integration tests

### DIFF
--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -74,7 +74,7 @@ def test_stac_item_next_link_returns_200():
         while next_links_untested:
             for collection in collections:
     
-                # All collections should have a dynamicaly generateed items link, even if no items exist
+                # All collections should have a dynamicaly generated items link, even if no items exist
                 items_link = _get_link(collection, "items")
                 assert items_link
                 items_url = items_link.get("href")


### PR DESCRIPTION
## What
Improvements to integration tests run after full instance is dispatched

1. Do not test API Gateway URLs when disabled
2. Walk through stac collections and attempt to test dynamic next links if the catalog includes a collection big enough to need item pagination.

# How tested
- Ran against stac-apis with and without next link bugs