### PR TITLE
fix: update workflows to use full commit hash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ vars.VEDA_AUTH_GIT_REF || 'main'}}
 
       - name: Configure AWS Credentials
-        aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 #v4.1.0
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 #v4.1.0
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "gh-${{ env.ENVIRONMENT }}-auth-deployment"


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-architecture/issues/569
- actions/checkout@v4 pinned to [v4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683)
- aws-actions/configure-aws-credentials@v4 pinned to [v4.1.0](https://github.com/aws-actions/configure-aws-credentials/commit/ececac1a45f3b08a01d2dd070d28d111c5fe6722)
- actions/setup-python@v4 pinned to [v4.8.0](https://github.com/actions/setup-python/commit/b64ffcaf5b410884ad320a9cfac8866006a109aa)
- actions/setup-node@v3 pinned to [v3.8.2](https://github.com/actions/setup-node/commit/1a4442cacd436585916779262731d5b162bc6ec7)
- falti/dotenv-action@v1.1 pinned to [v1.1.4](https://github.com/falti/dotenv-action/commit/a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5)
- actions/upload-artifact@v3 pinned to [v3.2.1-node20](https://github.com/actions/upload-artifact/commit/c24449f33cd45d4826c6702db7e49f7cdb9b551d)