### PR TITLE
fix: flatten airflow repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,7 +212,7 @@ jobs:
         with:
           env-file: ".env"
           env_aws_secret_name: ${{ vars.SM2A_ENVS_DEPLOYMENT_SECRET_NAME }}
-          dir: "${{ env.DIRECTORY }}/sm2a"
+          dir: "${{ env.DIRECTORY }}"
           script_path: "${{ github.workspace }}/scripts/generate_env_file.py"
 
       - name: Get SM2A Workflows API Endpoint


### PR DESCRIPTION
In https://github.com/NASA-IMPACT/veda-data-airflow/pull/352, we removed the `sm2a` directory as part of removing deprecated MWAA resources.