### PR TITLE
Deploy STAC Manager to Dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,6 @@ on:
         type: string
         required: true
         description: Environment to deploy to
-      DEPLOY_AUTH:
-        type: string
-        required: true
-        default: false
-        description: DEPLOY_AUTH
       DEPLOY_BACKEND:
         type: string
         required: true
@@ -71,53 +66,6 @@ concurrency:
 run-name: Deploy to ${{ inputs.environment }} environment by @${{ github.actor }}
 
 jobs:
-
-  deploy-veda-auth:
-    name: Deploy VEDA auth 🔐
-    runs-on: ubuntu-latest
-    env:
-      DIRECTORY: veda-auth
-      ENVIRONMENT: ${{ inputs.environment }}
-    environment: ${{ inputs.environment }}
-    if: ${{ inputs.DEPLOY_AUTH == 'true' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: "true"
-          submodules: "false"
-
-      - name: Checkout veda-auth submodule
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: "NASA-IMPACT/${{ env.DIRECTORY }}"
-          path: ${{ env.DIRECTORY }}
-          ref: ${{ vars.VEDA_AUTH_GIT_REF || 'main'}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 #v4.1.0
-        with:
-          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "gh-${{ env.ENVIRONMENT }}-auth-deployment"
-          aws-region: "us-west-2"
-
-      - name: Run auth deployment
-        id: deploy_auth_stack
-        uses: "./veda-auth/.github/actions/cdk-deploy"
-        with:
-          dir: "${{ env.DIRECTORY }}"
-          env_aws_secret_name: ${{ vars.VEDA_AUTH_DEPLOYMENT_SECRET || vars.DEPLOYMENT_ENV_SECRET_NAME }}
-
-      - name: Get Auth Stack Name
-        id: get_auth_stack
-        shell: bash
-        run: |
-          stack=$(jq 'keys_unsorted[0]' ${HOME}/cdk-outputs.json)
-          echo "auth_stackname=$stack" >> $GITHUB_OUTPUT
-
-    outputs:
-      auth_stack_name: ${{ steps.get_auth_stack.outputs.auth_stackname }}
 
   deploy-veda-backend:
     name: Deploy VEDA backend ⚙️

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,11 @@ on:
         required: true
         default: false
         description: DEPLOY_TITILER_CMR
+      DEPLOY_STAC_MANAGER:
+        type: string
+        required: true
+        default: false
+        description: DEPLOY_STAC_MANAGER
 
 concurrency:
   group: ${{ inputs.environment }}
@@ -508,6 +513,42 @@ jobs:
           env_aws_secret_name: ${{ vars.DEPLOYMENT_ENV_ROUTES_SECRET_NAME }}
           dir: "${{ env.DIRECTORY }}"
 
+  deploy-stac-manager:
+    name: Deploy STAC Manager
+    runs-on: ubuntu-latest
+    env:
+      DIRECTORY: stac-manager
+      ENVIRONMENT: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
+    if: ${{ inputs.DEPLOY_STAC_MANAGER == 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: "true"
+          submodules: "false"
+
+      - name: Checkout Stac Manager submodule
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "developmentseed/${{ env.DIRECTORY }}"
+          path: ${{ env.DIRECTORY }}
+          ref: ${{ vars.STAC_MANAGER_GIT_REF || 'main'}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 #v4.1.0
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "gh-${{ env.ENVIRONMENT }}-stac-manager-deployment"
+          aws-region: "us-west-2"
+
+      - name: Run stac-manager deployment
+        id: deploy_stac_manager
+        uses: "./stac-manager/.github/workflows/"
+        with:
+            env_file: ".env"
+            aws_region: ${{ vars.AWS_REGION }}
 
   test-deployment:
     name: Test Deployment 👨🏻‍🔬

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -57,6 +57,11 @@ on:
         required: true
         default: false
         description: DEPLOY_TITILER_CMR
+      DEPLOY_STAC_MANAGER:
+        type: boolean
+        required: true
+        default: false
+        description: DEPLOY_STAC_MANAGER
 
 run-name: |
   Dispatch to ${{ inputs.environment }} 
@@ -102,4 +107,5 @@ jobs:
       DEPLOY_TITILER_MULTIDIM: ${{ github.event.inputs.DEPLOY_TITILER_MULTIDIM }}
       DEPLOY_S3_DISASTER_RECOVERY: ${{ github.event.inputs.DEPLOY_S3_DISASTER_RECOVERY }}
       DEPLOY_TITILER_CMR: ${{ github.event.inputs.DEPLOY_TITILER_CMR }}
+      DEPLOY_STAC_MANAGER: ${{ github.event.inputs.DEPLOY_STAC_MANAGER }}
     secrets: inherit

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,11 +12,6 @@ on:
         type: environment
         required: true
         description: Environment to deploy to
-      DEPLOY_AUTH:
-        type: boolean
-        required: true
-        default: false
-        description: DEPLOY_AUTH
       DEPLOY_BACKEND:
         type: boolean
         required: true
@@ -65,7 +60,6 @@ on:
 
 run-name: |
   Dispatch to ${{ inputs.environment }} 
-  AUTH=${{ inputs.DEPLOY_AUTH }} 
   BACKEND=${{ inputs.DEPLOY_BACKEND }} 
   FEATURES=${{ inputs.DEPLOY_FEATURES_API }} 
   ROUTES=${{ inputs.DEPLOY_ROUTES }} 
@@ -98,7 +92,6 @@ jobs:
     needs: check-environment
     with:
       environment: ${{ github.event.inputs.environment }}
-      DEPLOY_AUTH: ${{ github.event.inputs.DEPLOY_AUTH}}
       DEPLOY_BACKEND: ${{ github.event.inputs.DEPLOY_BACKEND }}
       DEPLOY_FEATURES_API: ${{ github.event.inputs.DEPLOY_FEATURES_API }}
       DEPLOY_ROUTES: ${{ github.event.inputs.DEPLOY_ROUTES }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "titiler-cmr"]
 	path = titiler-cmr
 	url = https://github.com/developmentseed/titiler-cmr.git
+[submodule "stac-manager"]
+	path = stac-manager
+	url = https://github.com/developmentseed/stac-manager.git


### PR DESCRIPTION
Deploy STAC Manager to Dev to address [#590](https://github.com/NASA-IMPACT/veda-architecture/issues/590)

This is following the deployment steps I see in [Working on deployment for titiler-cmr](https://github.com/NASA-IMPACT/veda-deploy/commit/a90da880ce0765309812fd9fd613a04d3fdc4862) but using the github action in stac-manager
