### PR TITLE
[NOT FOR MERGE] add AWS_REQUEST_PAYER=requester for titiler-cmr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -441,6 +441,7 @@ jobs:
             script_path: "${{ github.workspace }}/scripts/generate_env_file.py"
           env:
             ADDITIONAL_ENV: '{"AWS_REQUEST_PAYER": "requester"}'
+            TITILER_CMR_S3_AUTH_STRATEGY: iam
 
   deploy-veda-routes:
     name: deploy VEDA routes 🔀


### PR DESCRIPTION
This PR adds the AWS_REQUEST_PAYER environment variable for titiler-cmr.

It's still a bit fuzzy to me which application environment variables should be in (1) the application deployment CDK code, (2) in the veda-deploy deployment workflow (done here) or (3) in the AWS SecretsManager Secret.

(1) seems like it should only be used if that environment variable should be set for ALL deployments for a particular application, for example GDAL settings in the case of titiler instances

(2) seems like a good fit when the environment variable should be used for all veda-deploy deployments of an application, but not be shared across applications

I've done (2) here because this is an environment variable that could unintentionally impact other applications if loaded. 

(3) seems like a good fit if the variable can be safely loaded by all applications, because it's namespaces OR if the variable should be shared by all deployments.

Concerns I see with (3) is any unintended consequences of sharing environment variables across applications and they are not maintained in code. For example, I just added `TITILER_CMR_S3_AUTH_STRATEGY=iam` to the AWS secret for smce-staging just now because I realized it was missing from new deployments using veda-deploy but how would current and future titiler-cmr devs know about that change? FYI @hrodmn **Update:** I ended up adding `TITILER_CMR_S3_AUTH_STRATEGY` environment variable here too as the application didn't appear to have loaded that environment variable via secrets even as I redeployed using this branch 🤔 have to think about this one a bit more.

@anayeaye @smohiudd let me know if you think some clarification on how environment variables should be managed would be helpful or if this is just noise 😅 