### PR TITLE
Set timeout on integration tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -512,6 +512,7 @@ jobs:
   test-deployment:
     name: Test Deployment 👨🏻‍🔬
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # Normally takes ~30s
     needs: [ deploy-veda-backend ]
     env:
       DIRECTORY: integration_test


### PR DESCRIPTION
I've had a [couple](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17274382018) of [deployments](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17279733162) today where the deployment was successful, and tests pass (when run from a local environment), but the action is hanging without errors or useful logs. This PR sets a reasonable limit on how long to let GHA keep trying before giving up and marking the step as failed.