### PR TITLE
fix: make keys consistent for veda-routes job 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -407,11 +407,10 @@ jobs:
         run: |
           python3 "${{ github.workspace }}/scripts/update_secret_with_inputs.py" \
             --secret-id ${{ vars.DEPLOYMENT_ENV_ROUTES_SECRET_NAME }} \
-            --prefix=VEDA_ \
             --raster_api_url=${{ needs.deploy-veda-backend.outputs.raster_api_url }} \
             --ingest_api_url=${{ needs.deploy-veda-backend.outputs.ingest_api_url }} \
             --stac_api_url=${{ needs.deploy-veda-backend.outputs.stac_api_url }} \
-            --stac_browser_bucket_name=${{ needs.deploy-veda-backend.outputs.stac_browser_bucket_name }} 
+            --stac_browser_bucket_name=${{ needs.deploy-veda-backend.outputs.stac_browser_bucket_name }}
 
       - name: Run deployment
         uses: "./veda-routes/.github/actions/cdk-deploy"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,15 +160,15 @@ jobs:
           stac_api_url=$(jq '.[keys_unsorted[0]].stacapiurl' ${HOME}/cdk-outputs.json)
           echo "stac_api_url=$stac_api_url" >> $GITHUB_OUTPUT
 
-          stac_browser_bucket_name=$(jq '.[keys_unsorted[0]].stacbrowserbucketname' ${HOME}/cdk-outputs.json)
-          echo "stac_browser_bucket_name=$stac_browser_bucket_name" >> $GITHUB_OUTPUT
+          stac_browser_bucket=$(jq '.[keys_unsorted[0]].stacbrowserbucketname' ${HOME}/cdk-outputs.json)
+          echo "stac_browser_bucket=$stac_browser_bucket" >> $GITHUB_OUTPUT
 
     outputs:
       backend_stack_name: ${{ steps.get_backend_stack.outputs.backend_stackname }}
       raster_api_url: ${{ steps.get_backend_stack.outputs.raster_api_url }}
       ingest_api_url: ${{ steps.get_backend_stack.outputs.ingest_api_url }}
       stac_api_url: ${{ steps.get_backend_stack.outputs.stac_api_url }}
-      stac_browser_bucket_name: ${{ steps.get_backend_stack.outputs.stac_browser_bucket_name }}
+      stac_browser_bucket: ${{ steps.get_backend_stack.outputs.stac_browser_bucket }}
 
   deploy-veda-data-airflow-sm2a:
     name: deploy VEDA data airflow SM2A 🛸
@@ -410,7 +410,7 @@ jobs:
             --raster_api_url=${{ needs.deploy-veda-backend.outputs.raster_api_url }} \
             --ingest_api_url=${{ needs.deploy-veda-backend.outputs.ingest_api_url }} \
             --stac_api_url=${{ needs.deploy-veda-backend.outputs.stac_api_url }} \
-            --stac_browser_bucket_name=${{ needs.deploy-veda-backend.outputs.stac_browser_bucket_name }}
+            --stac_browser_bucket=${{ needs.deploy-veda-backend.outputs.stac_browser_bucket }}
 
       - name: Run deployment
         uses: "./veda-routes/.github/actions/cdk-deploy"


### PR DESCRIPTION
Relevant issue: https://github.com/NASA-IMPACT/veda-backend/issues/545

This updates the env vars for the veda-routes job in order to remove the config prefix `VEDA_`. 