### PR TITLE
fix: update integration test env boolean parsing

### DIFF
--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -1,20 +1,34 @@
+"""
+API health checks for deployed VEDA backends
+"""
+import os
+
 import requests
 from dotenv import load_dotenv
-import os
 
 load_dotenv()
 
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean env var. Treats false/0/ and empty string as False"""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 def _get_link(obj: dict, rel: str) -> str:
     """get rel link from a stac object"""
-    return next((l for l in obj.get("links") if l["rel"]==rel), None)
+    return next((l for l in obj.get("links") if l["rel"] == rel), None)
+
 
 def test_stac_url_returns_200():
     base_url = os.getenv("VEDA_STAC_URL")
     stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
     custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = os.getenv("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT", False)
+    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     health_endpoint = "_mgmt/ping"
-    
+
     if not disable_default_apigw:
         url = f"{base_url}{health_endpoint}" # APIGW base url includes trailing /
         print(f"Checking APIGW stac-api {url=}")
@@ -26,14 +40,13 @@ def test_stac_url_returns_200():
         print(f"Checking custom host stac-api {url=}")
         response = requests.get(url)
         assert response.status_code == 200
-    
 
 
 def test_raster_url_returns_200():
     base_url = os.getenv("VEDA_RASTER_URL")
     raster_root_path = os.getenv("VEDA_RASTER_ROOT_PATH")
     custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = os.getenv("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT", False)
+    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     health_endpoint = "healthz"
 
     if not disable_default_apigw:
@@ -48,13 +61,14 @@ def test_raster_url_returns_200():
         response = requests.get(url)
         assert response.status_code == 200
 
+
 def test_stac_item_next_link_returns_200():
     base_url = os.getenv("VEDA_STAC_URL")
     stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
     custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = os.getenv("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT", False)
+    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     collections_endpoint = "collections"
-    
+
     if not disable_default_apigw:
         url = f"{base_url}/{collections_endpoint}"
         print(f"Checking APIGW stac-api {url=}")
@@ -66,14 +80,14 @@ def test_stac_item_next_link_returns_200():
         print(f"Checking links for custom host stac-api {url=}")
         response = requests.get(url)
         assert response.status_code == 200
-    
+
         # Walk check root path propagation through dynamic links when using custom host
         collections = response.json().get("collections")
         next_links_untested = True
 
         while next_links_untested:
             for collection in collections:
-    
+
                 # All collections should have a dynamicaly generated items link, even if no items exist
                 items_link = _get_link(collection, "items")
                 assert items_link
@@ -83,7 +97,7 @@ def test_stac_item_next_link_returns_200():
                 assert items_response.status_code == 200
                 items_json = items_response.json()
                 features = items_json.get("features")
-            
+
                 # The default page size is 10
                 if len(features) >= 10:
                     items_next_link = _get_link(items_json, "next")

--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -9,12 +9,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    """Parse a boolean env var. Treats false/0/ and empty string as False"""
+def _env_bool(name: str) -> bool:
     raw = os.getenv(name)
     if raw is None:
-        return default
-    return raw.strip().lower() in ("1", "true", "yes", "on")
+        return False
+    return raw.strip().lower() in ("1", "true")
 
 
 def _get_link(obj: dict, rel: str) -> str:


### PR DESCRIPTION
Related issue: https://github.com/NASA-IMPACT/veda-architecture/issues/762

While testing an eic-staging deployment,[ integration tests failed](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/26975128995/job/79606335690) on STAC health checks against the default execute-api URL, even though the API was healthy when hit on the correct path. This was revealed on eic-staging because it doesn't explicity set `VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT` in the env vars

Using the api gateway url for eic-staging, I checked
- `.../api/stac/_mgmt/ping` -> 200
- `.../_mgmt/ping` -> 404

The integration tests only applied VEDA_STAC_ROOT_PATH on the custom-host branch so the APIGW branch called `/_mgmt/ping` and `/collections` at the gateway root (but we don't want that in this case) 

### What Changed
- `_env_bool` introduced to properly parse our env vars that contain booleans (which get read in as strings)


