### PR TITLE
fix: remove Stephen from the list of approvers

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -86,7 +86,7 @@ jobs:
         # for the approval cannot exceed 60 minutes or the job will fail due to bad credentials
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: amarouane-ABDELHAK,slesaad,anayeaye,smohiudd,botanical,ividito,stephenkilbourn,sandrahoang686,aliziel
+          approvers: amarouane-ABDELHAK,slesaad,anayeaye,smohiudd,botanical,ividito,sandrahoang686,aliziel
           minimum-approvals: 1
           issue-title: "Deploying to ${{ github.event.inputs.environment }}"
           issue-body: "Please approve or deny the deployment"


### PR DESCRIPTION
This blocked my [recent attempt](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/27292801252/job/80617558153) to deploy titiler-cmr to mcp-prod:

```
error creating issue: POST https://api.github.com/repos/NASA-IMPACT/veda-deploy/issues: 422 Validation Failed [{Resource:Issue Field:assignees Code:invalid Message:assignees stephenkilbourn cannot be assigned to this issue}]
```