### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy 🚀
 
 permissions:
-  id-token: write
   contents: read
-  issues: write
-
 
 on:
   workflow_call:
@@ -70,6 +67,8 @@ jobs:
       ENVIRONMENT: ${{ inputs.environment }}
     if: ${{ inputs.DEPLOY_BACKEND == 'true' }}
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -135,6 +134,8 @@ jobs:
       ENVIRONMENT: ${{ inputs.environment }}
     if: ${{ inputs.DEPLOY_SM2A == 'true' }}
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -184,6 +185,8 @@ jobs:
     env:
       DIRECTORY: veda-features-api-cdk
       ENVIRONMENT: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -234,6 +237,8 @@ jobs:
       GH_PAT_CHECK: ${{ secrets.GH_PAT }}
     if: ${{ inputs.DEPLOY_MONITORING == 'true' }}
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -276,6 +281,8 @@ jobs:
         ENVIRONMENT: ${{ inputs.environment }}
       environment: ${{ inputs.environment }}
       if: ${{ inputs.DEPLOY_TITILER_MULTIDIM == 'true' }}
+      permissions:
+        id-token: write # Required to request OIDC token for use with AWS
 
       steps:
         - name: Checkout
@@ -314,6 +321,8 @@ jobs:
         ENVIRONMENT: ${{ inputs.environment }}
       environment: ${{ inputs.environment }}
       if: ${{ inputs.DEPLOY_S3_DISASTER_RECOVERY == 'true' }}
+      permissions:
+        id-token: write # Required to request OIDC token for use with AWS
 
       steps:
         - name: Checkout
@@ -357,6 +366,8 @@ jobs:
         ENVIRONMENT: ${{ inputs.environment }}
       environment: ${{ inputs.environment }}
       if: ${{ inputs.DEPLOY_TITILER_CMR == 'true' }}
+      permissions:
+        id-token: write # Required to request OIDC token for use with AWS
 
       steps:
         - name: Checkout
@@ -398,6 +409,8 @@ jobs:
     needs: [ deploy-veda-backend ]
     if: ${{ github.event.inputs.DEPLOY_ROUTES == 'true' }}
     environment: ${{ github.event.inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -466,6 +479,8 @@ jobs:
       ENVIRONMENT: ${{ inputs.environment }}
       AWS_DEFAULT_REGION: us-west-2
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
 

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,10 +1,5 @@
 name: Diff Infrastructure Changes
 
-permissions:
-  id-token: write
-  contents: read
-  issues: read
-
 on:
   workflow_dispatch:
     inputs:
@@ -28,6 +23,8 @@ jobs:
       ENVIRONMENT: ${{ inputs.environment }}
     if: ${{ inputs.IaC == 'SM2A' }}
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -81,7 +81,7 @@ jobs:
       # Production deploys require manual approval and each prod environment has its own approver list (submit PR to change).
       - name: Manual deployment approval (ghgc-mcp-production-blue)
         if: ${{ github.event.inputs.environment == 'ghgc-mcp-production-blue' }}
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 #v1.12.0
         timeout-minutes: 60 # The approver will have 1 hour to approve this request
         # Why 1h? Because GitHub App tokens expire after 1 hour which implies duration
         # for the approval cannot exceed 60 minutes or the job will fail due to bad credentials
@@ -94,7 +94,7 @@ jobs:
 
       - name: Manual deployment approval (mcp-prod)
         if: ${{ github.event.inputs.environment == 'mcp-prod' }}
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 #v1.12.0
         timeout-minutes: 60
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Manual deployment approval (eic-prod)
         if: ${{ github.event.inputs.environment == 'eic-prod' }}
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 #v1.12.0
         timeout-minutes: 60
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Manual deployment approval (disasters-prod)
         if: ${{ github.event.inputs.environment == 'disasters-prod' }}
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 #v1.12.0
         timeout-minutes: 60
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,10 +1,5 @@
 name: Dispatch ⛟
 
-permissions:
-  id-token: write
-  contents: write
-  issues: write
-
 on:
   workflow_dispatch:
     inputs:
@@ -77,6 +72,8 @@ jobs:
   check-environment:
     runs-on: ubuntu-latest
     name: Got ${{ github.event.inputs.environment }}
+    permissions:
+      issues: write
     steps:
       # Production deploys require manual approval and each prod environment has its own approver list (submit PR to change).
       - name: Manual deployment approval (ghgc-mcp-production-blue)
@@ -140,11 +137,15 @@ jobs:
       DEPLOY_S3_DISASTER_RECOVERY: ${{ github.event.inputs.DEPLOY_S3_DISASTER_RECOVERY }}
       DEPLOY_TITILER_CMR: ${{ github.event.inputs.DEPLOY_TITILER_CMR }}
     secrets: inherit
+    permissions:
+      id-token: write
 
   update-deployment-status:
     name: Update Deployment Status
     uses: "./.github/workflows/update_deployment_status.yml"
     needs: deploy-veda-components
+    permissions:
+      contents: write
     with:
       environment: ${{ github.event.inputs.environment }}
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/update_deployment_status.yml
+++ b/.github/workflows/update_deployment_status.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout deployment-state branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: deployment-state
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
 

--- a/.github/workflows/update_deployment_status.yml
+++ b/.github/workflows/update_deployment_status.yml
@@ -7,13 +7,12 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   update-status-md:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout deployment-state branch


### PR DESCRIPTION
>[!NOTE]
>See https://github.com/NASA-IMPACT/veda-keycloak/pull/253 for more detail on OSSF Scorecard + Dependabot configs, removed repeated detail to help reviewers and better highlight repo-specific deltas.

---

- Dependabot version updates added:
    - `pip` (deploy script dependencies)
    - `github-actions` (CI)
- Commit SHAs
    - Pinned to latest release per major version
- [OSSF Scorecard](https://github.com/ossf/scorecard-action) added
- Token permissions
    - Move write permissions from top-level (all jobs) to specific job required
    - Remove excess write permissions