### PR TITLE
fix: modify integration tests

### DIFF
--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -1,19 +1,13 @@
 """
-API health checks for deployed VEDA backends
+API health checks for deployed VEDA backends using custom host endpoints
 """
 import os
 
+import pytest
 import requests
 from dotenv import load_dotenv
 
 load_dotenv()
-
-
-def _env_bool(name: str) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return False
-    return raw.strip().lower() in ("1", "true")
 
 
 def _get_link(obj: dict, rel: str) -> str:
@@ -22,88 +16,76 @@ def _get_link(obj: dict, rel: str) -> str:
 
 
 def test_stac_url_returns_200():
-    base_url = os.getenv("VEDA_STAC_URL")
+    custom_host = os.getenv("VEDA_CUSTOM_HOST")
     stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
-    custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     health_endpoint = "_mgmt/ping"
 
-    if not disable_default_apigw:
-        url = f"{base_url}{stac_root_path}/{health_endpoint}"
-        print(f"Checking APIGW stac-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    if not custom_host:
+        pytest.skip("VEDA_CUSTOM_HOST not set. Skipping health test.")
 
-    if custom_host:
-        url = f"https://{custom_host}/{stac_root_path.rstrip('/')}/{health_endpoint}"
-        print(f"Checking custom host stac-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    assert stac_root_path, "VEDA_STAC_ROOT_PATH must be set"
+
+    url = f"https://{custom_host}/{stac_root_path.strip('/')}/{health_endpoint}"
+    print(f"Checking custom host stac-api {url=}")
+    response = requests.get(url)
+    assert response.status_code == 200
 
 
 def test_raster_url_returns_200():
-    base_url = os.getenv("VEDA_RASTER_URL")
+    custom_host = os.getenv("VEDA_CUSTOM_HOST")
     raster_root_path = os.getenv("VEDA_RASTER_ROOT_PATH")
-    custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     health_endpoint = "healthz"
 
-    if not disable_default_apigw:
-        url = f"{base_url}{raster_root_path}/{health_endpoint}"
-        print(f"Checking APIGW raster-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    if not custom_host:
+        pytest.skip("VEDA_CUSTOM_HOST not set. Skipping health test.")
 
-    if custom_host:
-        url = f"https://{custom_host}/{raster_root_path.rstrip('/')}/{health_endpoint}"
-        print(f"Checking custom host raster-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    assert raster_root_path, "VEDA_RASTER_ROOT_PATH must be set"
+
+    url = f"https://{custom_host}/{raster_root_path.strip('/')}/{health_endpoint}"
+    print(f"Checking custom host raster-api {url=}")
+    response = requests.get(url)
+    assert response.status_code == 200
 
 
 def test_stac_item_next_link_returns_200():
-    base_url = os.getenv("VEDA_STAC_URL")
+    custom_host = os.getenv("VEDA_CUSTOM_HOST")
     stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
-    custom_host = os.getenv("VEDA_CUSTOM_HOST", None)
-    disable_default_apigw = _env_bool("VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT")
     collections_endpoint = "collections"
 
-    if not disable_default_apigw:
-        url = f"{base_url}{stac_root_path}/{collections_endpoint}"
-        print(f"Checking APIGW stac-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    if not custom_host:
+        pytest.skip("VEDA_CUSTOM_HOST not set. Skipping health test.")
 
-    if custom_host:
-        url = f"https://{custom_host}/{stac_root_path.rstrip('/')}/{collections_endpoint}"
-        print(f"Checking links for custom host stac-api {url=}")
-        response = requests.get(url)
-        assert response.status_code == 200
+    assert stac_root_path, "VEDA_STAC_ROOT_PATH must be set"
 
-        # Walk check root path propagation through dynamic links when using custom host
-        collections = response.json().get("collections")
-        next_links_untested = True
+    url = f"https://{custom_host}/{stac_root_path.strip('/')}/{collections_endpoint}"
+    print(f"Checking links for custom host stac-api {url=}")
+    response = requests.get(url)
+    assert response.status_code == 200
 
-        while next_links_untested:
-            for collection in collections:
+    # Walk check root path propagation through dynamic links when using custom host
+    collections = response.json().get("collections")
+    next_links_untested = True
 
-                # All collections should have a dynamicaly generated items link, even if no items exist
-                items_link = _get_link(collection, "items")
-                assert items_link
-                items_url = items_link.get("href")
-                assert items_url
-                items_response = requests.get(items_url)
-                assert items_response.status_code == 200
-                items_json = items_response.json()
-                features = items_json.get("features")
+    while next_links_untested:
+        for collection in collections:
 
-                # The default page size is 10
-                if len(features) >= 10:
-                    items_next_link = _get_link(items_json, "next")
-                    assert items_next_link
-                    next_url = items_next_link.get("href")
-                    assert next_url
-                    next_response = requests.get(next_url)
-                    assert next_response.status_code == 200
-                    next_links_untested = False
-                    break
+            # All collections should have a dynamicaly generated items link, even if no items exist
+            items_link = _get_link(collection, "items")
+            assert items_link
+            items_url = items_link.get("href")
+            assert items_url
+            items_response = requests.get(items_url)
+            assert items_response.status_code == 200
+            items_json = items_response.json()
+            features = items_json.get("features")
+
+            # The default page size is 10
+            if len(features) >= 10:
+                items_next_link = _get_link(items_json, "next")
+                assert items_next_link
+                next_url = items_next_link.get("href")
+                assert next_url
+                next_response = requests.get(next_url)
+                assert next_response.status_code == 200
+                next_links_untested = False
+                break

--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -29,7 +29,7 @@ def test_stac_url_returns_200():
     health_endpoint = "_mgmt/ping"
 
     if not disable_default_apigw:
-        url = f"{base_url}{health_endpoint}" # APIGW base url includes trailing /
+        url = f"{base_url}{stac_root_path}/{health_endpoint}"
         print(f"Checking APIGW stac-api {url=}")
         response = requests.get(url)
         assert response.status_code == 200
@@ -49,7 +49,7 @@ def test_raster_url_returns_200():
     health_endpoint = "healthz"
 
     if not disable_default_apigw:
-        url = os.path.join(base_url, health_endpoint)
+        url = f"{base_url}{raster_root_path}/{health_endpoint}"
         print(f"Checking APIGW raster-api {url=}")
         response = requests.get(url)
         assert response.status_code == 200
@@ -69,7 +69,7 @@ def test_stac_item_next_link_returns_200():
     collections_endpoint = "collections"
 
     if not disable_default_apigw:
-        url = f"{base_url}/{collections_endpoint}"
+        url = f"{base_url}{stac_root_path}/{collections_endpoint}"
         print(f"Checking APIGW stac-api {url=}")
         response = requests.get(url)
         assert response.status_code == 200

--- a/integration_test/test_stac_pagination_next_link.py
+++ b/integration_test/test_stac_pagination_next_link.py
@@ -24,10 +24,12 @@ def test_collection_pagination_next_link_is_valid():
     dynamically generated links are used by end-users.
     """
     custom_host = os.getenv("VEDA_CUSTOM_HOST")
-    stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH", "")
+    stac_root_path = os.getenv("VEDA_STAC_ROOT_PATH")
 
     if not custom_host:
         pytest.skip("VEDA_CUSTOM_HOST environment variable not set. Skipping pagination test.")
+
+    assert stac_root_path, "VEDA_STAC_ROOT_PATH must be set"
 
     #  Construct the URL to the main collections endpoint
     collections_url = f"https://{custom_host}/{stac_root_path.strip('/')}/collections"


### PR DESCRIPTION
### Context

https://github.com/NASA-IMPACT/veda-deploy/issues/212 

When `VEDA_DISABLE_DEFAULT_APIGW_ENDPOINT` is false, we need to include the root path in the tests. [The tests were trying to hit https://{apigw}/_mgmt/ping instead of https://{apigw}/api/stac/_mgmt/ping ](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/29617213403/job/88019881827) and failing because it needs the root path. This PR is related https://github.com/NASA-IMPACT/veda-deploy/pull/196 and it ended up revealing this bug because now the env var is parsed correctly.

I think our API Gateway stages mount the API under the root path (for example: https://github.com/NASA-IMPACT/veda-backend/blob/main/raster_api/runtime/src/app.py#L69) so leaving it out is a bug that needs to be fixed (which this PR addresses)