### PR TITLE
fix: stac item next link test modification

### DIFF
--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -63,29 +63,27 @@ def test_stac_item_next_link_returns_200():
     assert response.status_code == 200
 
     # Walk check root path propagation through dynamic links when using custom host
-    collections = response.json().get("collections")
-    next_links_untested = True
+    # and use a small page size so next links appear with fewer items
+    collections = response.json().get("collections") or []
+    for collection in collections:
+        items_link = _get_link(collection, "items")
+        assert items_link
+        items_url = items_link.get("href")
+        assert items_url
 
-    while next_links_untested:
-        for collection in collections:
+        items_response = requests.get(items_url, params={"limit": 1})
+        assert items_response.status_code == 200
+        items_json = items_response.json()
 
-            # All collections should have a dynamicaly generated items link, even if no items exist
-            items_link = _get_link(collection, "items")
-            assert items_link
-            items_url = items_link.get("href")
-            assert items_url
-            items_response = requests.get(items_url)
-            assert items_response.status_code == 200
-            items_json = items_response.json()
-            features = items_json.get("features")
+        items_next_link = _get_link(items_json, "next")
+        if not (items_next_link and items_next_link.get("href")):
+            continue
 
-            # The default page size is 10
-            if len(features) >= 10:
-                items_next_link = _get_link(items_json, "next")
-                assert items_next_link
-                next_url = items_next_link.get("href")
-                assert next_url
-                next_response = requests.get(next_url)
-                assert next_response.status_code == 200
-                next_links_untested = False
-                break
+        next_url = items_next_link["href"]
+        next_response = requests.get(next_url)
+        assert next_response.status_code == 200
+        return
+
+    print(f"Skipping. No collection 'next' items link found.")
+    pytest.skip("No collection produced a paginated 'next' items link.")
+

--- a/integration_test/test_api_health.py
+++ b/integration_test/test_api_health.py
@@ -65,6 +65,10 @@ def test_stac_item_next_link_returns_200():
     # Walk check root path propagation through dynamic links when using custom host
     # and use a small page size so next links appear with fewer items
     collections = response.json().get("collections") or []
+
+    if not collections:
+        pytest.skip("No collections found in STAC catalog.")
+
     for collection in collections:
         items_link = _get_link(collection, "items")
         assert items_link

--- a/integration_test/test_stac_pagination_next_link.py
+++ b/integration_test/test_stac_pagination_next_link.py
@@ -43,6 +43,9 @@ def test_collection_pagination_next_link_is_valid():
     except (requests.exceptions.RequestException, ValueError) as e:
         pytest.fail(f"Could not fetch or parse collections from {collections_url}. Error: {e}")
 
+    if not collections:
+        pytest.skip("No collections found in STAC catalog.")
+
     # Iterate through each collection to find one with pagination
     for collection_summary in collections:
         collection_id = collection_summary.get("id")
@@ -79,7 +82,7 @@ def test_collection_pagination_next_link_is_valid():
             # Make a GET request to the 'next' URL
             try:
                 next_page_response = requests.get(next_url)
-                
+
                 # Assert that the link is valid and returns a 200 OK status
                 assert next_page_response.status_code == 200, f"'next' link for {collection_id} failed with status {next_page_response.status_code}"
                 print(f"  - Success! 'next' link returned status {next_page_response.status_code}.")


### PR DESCRIPTION
This PR fixes our test for testing the STAC item next link

### Testing done

I pullled down the MCP env vars and ran it locally (I don't think there's another way to test the changes)
```
╰─$ pytest -v                                       
================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/jennifertran/Code/ds/VEDA/veda-deploy/integration_test/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/jennifertran/Code/ds/VEDA/veda-deploy/integration_test
collected 4 items                                                                                                                                        

test_api_health.py::test_stac_url_returns_200 PASSED                                                                                               [ 25%]
test_api_health.py::test_raster_url_returns_200 PASSED                                                                                             [ 50%]
test_api_health.py::test_stac_item_next_link_returns_200 PASSED                                                                                    [ 75%]
test_stac_pagination_next_link.py::test_collection_pagination_next_link_is_valid PASSED                                                            [100%]

=================================================================== 4 passed in 15.65s ===================================================================

```